### PR TITLE
feat: upgrade icons to Font Awesome 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 
 </div>
 
-
-
 ![BioDrop CLI demo GIF](https://github.com/Pradumnasaraf/BioDrop-CLI/assets/51878265/25c74ca0-22bf-473c-8ad2-fe9e768c989c)
 
 ### ⭐️ Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "biodrop-cli",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^1.4.0",
@@ -15,7 +15,7 @@
         "enquirer": "^2.3.6",
         "json-format": "^1.0.1",
         "open": "^9.1.0",
-        "react-icons": "^4.9.0"
+        "react-icons": "^4.11.0"
       },
       "bin": {
         "biodrop-cli": "src/index.js"
@@ -1913,9 +1913,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.9.0.tgz",
-      "integrity": "sha512-ijUnFr//ycebOqujtqtV9PFS7JjhWg0QU6ykURVHuL4cbofvRCf3f6GMn9+fBktEFQOIVZnuAYLZdiyadRQRFg==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
       "peerDependencies": {
         "react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lint:fix": "eslint --fix ."
   },
   "keywords": [
+    "CLI",
+    "Node CLI",
     "BioDrop-cli",
     "BioDrop"
   ],
@@ -30,7 +32,7 @@
     "enquirer": "^2.3.6",
     "json-format": "^1.0.1",
     "open": "^9.1.0",
-    "react-icons": "^4.9.0"
+    "react-icons": "^4.11.0"
   },
   "devDependencies": {
     "eslint": "^8.43.0",

--- a/src/shared/assets/icons.js
+++ b/src/shared/assets/icons.js
@@ -1,4 +1,4 @@
-import FaIcons from "react-icons/fa/index.js";
+import FaIcons from "react-icons/fa6/index.js";
 import SiIcons from "react-icons/si/index.js";
 import enquirer from "enquirer";
 import chalk from "chalk";


### PR DESCRIPTION
## 👨‍💻 Changes proposed

Add support for Font Awesome 6 by upgrading `react-icons` to 4.11

